### PR TITLE
Update to Swift 4.2, fixed compiler warnings

### DIFF
--- a/CloudKitGDPR.podspec
+++ b/CloudKitGDPR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'CloudKitGDPR'
-  s.version = '1.0.0'
+  s.version = '1.0.1'
   s.license = 'MIT'
   s.summary = 'Framework for allowing users to manage data stored in iCloud.'
   s.homepage = 'https://github.com/arturgrigor/CloudKitGDPR'

--- a/CloudKitGDPR.xcodeproj/project.pbxproj
+++ b/CloudKitGDPR.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = "Artur Grigor";
 				TargetAttributes = {
 					FE0EDBCB2099196E00CC16BF = {
@@ -229,7 +229,7 @@
 					};
 					FE865D1520990C4000AA9E41 = {
 						CreatedOnToolsVersion = 9.3;
-						LastSwiftMigration = 0930;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -520,6 +520,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
@@ -533,7 +534,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -542,6 +544,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
@@ -554,7 +557,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.arturgrigor.CloudKitGDPR;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/CloudKitGDPR.xcodeproj/xcshareddata/xcschemes/CloudKitGDPR.xcscheme
+++ b/CloudKitGDPR.xcodeproj/xcshareddata/xcschemes/CloudKitGDPR.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/CKDatabase+AllRecords.swift
+++ b/Sources/CKDatabase+AllRecords.swift
@@ -22,10 +22,10 @@ public extension CKDatabase {
     ///   - query: The query object containing the parameters for the search.
     ///   - zoneID: The ID of the zone to search. Search results are limited to records in the specified zone. Specify `nil` to search the default zone of the database.
     ///   - completion: A closure that will be called upon completion.
-    public func allRecords(forQuery query: CKQuery, inZoneWith zoneID: CKRecordZoneID?, completion: @escaping ([CKRecord]?, Error?) -> Void) {
+    public func allRecords(forQuery query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completion: @escaping ([CKRecord]?, Error?) -> Void) {
         var result: [CKRecord] = []
         let operation = CKQueryOperation(query: query)
-        operation.resultsLimit = CKQueryOperationMaximumResults
+        operation.resultsLimit = CKQueryOperation.maximumResults
         operation.zoneID = zoneID
         operation.recordFetchedBlock = { record in
             result.append(record)
@@ -47,7 +47,7 @@ public extension CKDatabase {
     /// - Parameters:
     ///   - initialOperation: The initial operation.
     ///   - completion: A closure that will be called after fetching all data.
-    fileprivate func queryCompletionBlock(forInitialOperation initialOperation: CKQueryOperation, completion: @escaping (Error?) -> Void) -> ((CKQueryCursor?, Error?) -> Void) {
+    fileprivate func queryCompletionBlock(forInitialOperation initialOperation: CKQueryOperation, completion: @escaping (Error?) -> Void) -> ((CKQueryOperation.Cursor?, Error?) -> Void) {
         return { cursor, error in
             if let error = error {
                 completion(error)

--- a/Sources/CSVDataTransformer.swift
+++ b/Sources/CSVDataTransformer.swift
@@ -23,7 +23,7 @@ open class CSVDataTransformer: DataTransformer {
     // MARK: - Properties -
     
     /// Dispatch queue.
-    open let dispatchQueue: DispatchQueue
+    public let dispatchQueue: DispatchQueue
     
     // MARK: - Initialization -
     
@@ -37,7 +37,7 @@ open class CSVDataTransformer: DataTransformer {
     // MARK: - Constructors -
     
     /// Default instance.
-    open static let `default` = CSVDataTransformer(dispatchQueue: DispatchQueue(label: "GDPR.CSVExporter"))
+    public static let `default` = CSVDataTransformer(dispatchQueue: DispatchQueue(label: "GDPR.CSVExporter"))
     
     // MARK: - GDPRExporter Methods -
     

--- a/Sources/GDPR.swift
+++ b/Sources/GDPR.swift
@@ -24,7 +24,7 @@ open class GDPR {
     /// Records by Record Types by Containers.
     public typealias RecordsByRecordTypeByContainer = [CKContainer: [String: [CKRecord]]]
     /// Record Zone IDs by Containers.
-    public typealias RecordsZoneIDsByContainer = [CKContainer: [CKRecordZoneID]]
+    public typealias RecordsZoneIDsByContainer = [CKContainer: [CKRecordZone.ID]]
     /// Container name mapping.
     public typealias ContainerNameMapping = [CKContainer: String]
     
@@ -42,10 +42,10 @@ open class GDPR {
     // MARK: - Properties -
     
     /// Record Types by Containers.
-    open let metadata: RecordTypesByContainer
+    public let metadata: RecordTypesByContainer
     
     /// Container name mapping.
-    open let containerNameMapping: ContainerNameMapping
+    public let containerNameMapping: ContainerNameMapping
     
     // MARK: - Initialization -
     

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/JSONDataTransformer.swift
+++ b/Sources/JSONDataTransformer.swift
@@ -23,7 +23,7 @@ open class JSONDataTransformer: DataTransformer {
     // MARK: - Properties -
     
     /// Dispatch queue.
-    open let dispatchQueue: DispatchQueue
+    public let dispatchQueue: DispatchQueue
     
     // MARK: - Initialization -
     
@@ -37,7 +37,7 @@ open class JSONDataTransformer: DataTransformer {
     // MARK: - Constructors -
     
     /// Default instance.
-    open static let `default` = JSONDataTransformer(dispatchQueue: DispatchQueue(label: "GDPR.JSONExporter"))
+    public static let `default` = JSONDataTransformer(dispatchQueue: DispatchQueue(label: "GDPR.JSONExporter"))
     
     // MARK: - GDPRExporter Methods -
     


### PR DESCRIPTION
To avoid those pesky warnings when I'm using the Xcode beta, I have taken the time to migrate this framework to Swift version 4.2 and fixed the compiler warnings. I hope that's ok.